### PR TITLE
Stop special handling for Armadillo versions for HDF5.

### DIFF
--- a/src/mlpack/tests/load_save_test.cpp
+++ b/src/mlpack/tests/load_save_test.cpp
@@ -518,9 +518,7 @@ BOOST_AUTO_TEST_CASE(SavePGMBinaryTest)
   remove("test_file.pgm");
 }
 
-#if defined(ARMA_USE_HDF5) && (ARMA_VERSION_MAJOR == 3 \
-    || (ARMA_VERSION_MAJOR == 4 && (ARMA_VERSION_MINOR < 300 \
-    ||  ARMA_VERSION_MINOR > 400)))
+#if defined(ARMA_USE_HDF5)
 /**
  * Make sure load as HDF5 is successful.
  */


### PR DESCRIPTION
This should hopefully fix a few more failing tests in the matrix build.
